### PR TITLE
Very minor fixes: Add SLF4J so we can see Spark's logs, and fix a typo (that doesn't really matter)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.22</version>
+        </dependency>
     </dependencies>
-
-
-
 
 </project>

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -4,7 +4,7 @@ var gameModel;
 $( document ).ready(function() {
 
   $.getJSON("model", function( json ) {
-    displayGameState(currModel);
+    displayGameState(json);
     gameModel = json;
    });
 });


### PR DESCRIPTION
If you've run the project, you might have noticed the following message:
`SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.`

Spark depends on SLF4J if we want to see logs (and I do). I added the dependency to `pom.xml`, so you'll be able to install SLF4J using Maven just by doing `mvn install`.

The other thing this PR does is fix a typo in the view's javascript. If you look at the javascript file, you'll see in several locations when the server responds to a request, the gameModel var is updated with the new model, and that model is displayed with displayGameState(). Towards the top of the file, where the typo is, it tries to `displayGameState(currModel)` when the argument is actually called `json`.

This bug doesn't really matter, as the blank game state received from the /model request has no ships placed or shots fired, so nobody would care that it's failing to call displayGameState() anyways. It just throws an error in the JS console.